### PR TITLE
Switch planning to departures-only mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,8 @@
 - Progress labels log a concise flight summary (best fare, airline, leg).
 - Rows deduplicate identical flights per journey leg to avoid repeated segments.
 - Each plan saves an `<csv_stem>_itineraries.xlsx` workbook (default unlimited per leg; clamp via `leg_limit`).
+- Workbook leg exports now include `origin_code` and `destination_code` columns.
+- `stop_notes` now include arrival code plus layover code/city/duration when available.
 - CLI surfaces itinerary limits and recommended values when exporting workbooks.
 - The progress bar announces `Ctrl+C`; interrupting saves `draft-<original>.csv` and reports remaining itineraries.
 - Legs spanning more than seven departure days emit an extreme warning because those runs can last hours and invite Google anti-abuse throttling.
@@ -98,4 +100,4 @@
 - `.github/workflows/release.yml` auto-runs on pushes to `main` with a patch bump when changes touch `awesome_cheap_flights/*.py`, root `*.toml`, or `uv.lock`, and HEAD differs from the last release tag; append `[minor]` to the end of the first commit subject to force a minor bump. The workflow builds with `uv tool run --from build pyproject-build --wheel --sdist`, uploads via `uvx --from twine twine upload`, then tags/pushes/drafts the GitHub Release. Manually dispatch when you need `minor` or `current`.
 - Provide `PYPI_TOKEN` in repo secrets with upload scope.
 
-Last commit id: a77b356d42a3438e8bb93f3d20d65ae482ea0832
+Last commit id: ee53d5f393f63bca27a81f4b9cfd4ddbad7a183d

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@
 
 - `awesome_cheap_flights/cli.py`: CLI arguments + config loader for console script and uvx runs; direct module execution now exits via `SystemExit(main())`.
 - `awesome_cheap_flights/__main__.py`: Enables `python -m awesome_cheap_flights` compatibility.
-- `awesome_cheap_flights/pipeline.py`: Core scraping/search pipeline including data structures, HTML parsing, and CSV export utilities; hidden legs now only bridge a single intermediate stop.
+- `awesome_cheap_flights/pipeline.py`: Core scraping/search pipeline including data structures, HTML parsing, and CSV export utilities; plan legs are ordered by `departures` keys and hidden legs only bridge connected adjacent legs.
 - `sample.config.yaml`: Minimal example config used for smoke tests; copy to `config.yaml` for local overrides.
 - `output/`: Git-ignored directory for generated CSV files (only tracked when explicitly whitelisted).
 
@@ -42,6 +42,7 @@
 - Each plan saves an `<csv_stem>_itineraries.xlsx` workbook (default unlimited per leg; clamp via `leg_limit`).
 - Workbook leg exports now include `origin_code` and `destination_code` columns.
 - `stop_notes` now include arrival code plus layover code/city/duration when available.
+- Missing prices render as `N/A` in CSV and workbook exports.
 - CLI surfaces itinerary limits and recommended values when exporting workbooks.
 - The progress bar announces `Ctrl+C`; interrupting saves `draft-<original>.csv` and reports remaining itineraries.
 - Legs spanning more than seven departure days emit an extreme warning because those runs can last hours and invite Google anti-abuse throttling.
@@ -81,6 +82,8 @@
 ## Configuration Tips
 
 - Store local secrets or large route lists in `config.yaml` (git-ignored). Use `sample.config.yaml` only for reproducible smoke tests.
+- Plan `path` is removed; `departures` key order defines leg sequence.
+- Missing links between adjacent departure legs are treated as surface transfers.
 - Prefer `outbound` / `inbound` keys for itineraries; ranges are specified via `{start, end}` blocks.
 - Set the top-level `currency` key (uppercase ISO code) when you need fares labeled in something other than USD.
 - Use the `passengers` key to control the number of adult seats (defaults to 1).
@@ -100,4 +103,4 @@
 - `.github/workflows/release.yml` auto-runs on pushes to `main` with a patch bump when changes touch `awesome_cheap_flights/*.py`, root `*.toml`, or `uv.lock`, and HEAD differs from the last release tag; append `[minor]` to the end of the first commit subject to force a minor bump. The workflow builds with `uv tool run --from build pyproject-build --wheel --sdist`, uploads via `uvx --from twine twine upload`, then tags/pushes/drafts the GitHub Release. Manually dispatch when you need `minor` or `current`.
 - Provide `PYPI_TOKEN` in repo secrets with upload scope.
 
-Last commit id: ee53d5f393f63bca27a81f4b9cfd4ddbad7a183d
+Last commit id: 4c1f10512d3ea93aa615e249a18a54c598f8e339

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Run the CLI locally for iterative tweaks.
 uv run python -m awesome_cheap_flights.cli --config config.yaml --output output/dev.csv
 ```
 - Copy sample.config.yaml into config.yaml before editing routes.
-- Update config.yaml to adjust places, paths, or windows.
+- Update config.yaml to adjust places, legs, or windows.
 - Set UV_CACHE_DIR=$(pwd)/.cache/uv to isolate uv cache.
 - Use --output <path> to force a specific CSV file, directory, or pattern. Omit it to keep timestamped files inside output/.
 - Combine CLI overrides with commas or repeated flags for airports.
@@ -89,7 +89,9 @@ uv run python -m awesome_cheap_flights.cli --config config.yaml --output output/
 - Departures allow per-leg max_stops overrides alongside date selectors.
 - Date windows spanning more than seven days trigger an extreme warning because runs can take hours and risk Google anti-abuse blocks.
 - Output directory and filename_pattern customize CSV targets.
-- Plans list places, path, departures, filters, and options blocks.
+- Plans list places, ordered departures, filters, and options blocks.
+- Departure key order defines leg sequence for searches and workbooks.
+- Missing links between adjacent departure keys are treated as surface transfers.
 - Options include include_hidden toggles and hop caps per plan.
 - CLI overrides accept plan, currency, passengers, seat class, itinerary limits, proxy, concurrency, debug.
 
@@ -119,7 +121,6 @@ plans:
     places:
       home: [ICN]
       city: [FUK, HKG]
-    path: [home, city, home]
     departures:
       "home->city":
         dates: ["2026-01-01", "2026-01-02"]
@@ -143,7 +144,7 @@ Each plan expands airport combinations and departure calendars automatically.
 ## Output fields
 - plan_name marks the source plan for grouping.
 - journey_id stores a stable slug per journey.
-- journey_label summarizes path and chosen dates.
+- journey_label summarizes endpoint codes and chosen dates.
 - variant denotes scheduled legs or hidden discoveries.
 - leg_sequence tracks zero-based leg ordering.
 - origin_place and destination_place map to place identifiers.
@@ -155,7 +156,7 @@ Each plan expands airport combinations and departure calendars automatically.
 - stops and stop_notes capture arrival code plus stopover code, city, duration.
 - seat_class records the requested cabin per segment.
 - hidden_departure_at lists hidden-hop departure times when available.
-- price stores integer fare digits.
+- price stores fare digits or `N/A` when unavailable.
 - is_best mirrors Google Flights highlights.
 - currency shows the fare currency code.
 
@@ -163,7 +164,7 @@ Each plan expands airport combinations and departure calendars automatically.
 - Each run emits `<csv_stem>_itineraries.xlsx` alongside the CSV export.
 - Columns follow `<origin_place>-><destination_place>_<field>` naming (e.g., `home->las_price`).
 - Per-leg fields cover origin_code, destination_code, price, currency, seat_class, departure timestamps (including hidden departures), airline, stops, stop_notes, duration_hours, and variant flags.
-- Totals include `total_price`, `total_currency`, and aggregated `total_duration_hours` when data is complete.
+- Totals include `total_price`, `total_currency`, and aggregated `total_duration_hours`.
 - Tune `leg_limit` (flights per leg, 0 = unlimited, 10 recommended) and `max_combinations` (0 = unlimited) to balance coverage versus file size.
 
 ## Project layout
@@ -178,4 +179,4 @@ Each plan expands airport combinations and departure calendars automatically.
 - Provide a PYPI_TOKEN secret with publish permissions.
 - Select current to reuse the existing version during manual runs.
 
-Last commit id: ee53d5f393f63bca27a81f4b9cfd4ddbad7a183d
+Last commit id: 4c1f10512d3ea93aa615e249a18a54c598f8e339

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Each plan expands airport combinations and departure calendars automatically.
 - departure_date, departure_time, departure_at hold normalized timestamps.
 - duration_hours stores decimal leg durations.
 - airline holds the carrier label.
-- stops and stop_notes capture layover counts and codes.
+- stops and stop_notes capture arrival code plus stopover code, city, duration.
 - seat_class records the requested cabin per segment.
 - hidden_departure_at lists hidden-hop departure times when available.
 - price stores integer fare digits.
@@ -162,7 +162,7 @@ Each plan expands airport combinations and departure calendars automatically.
 ## Excel itinerary workbook
 - Each run emits `<csv_stem>_itineraries.xlsx` alongside the CSV export.
 - Columns follow `<origin_place>-><destination_place>_<field>` naming (e.g., `home->las_price`).
-- Per-leg fields cover price, currency, seat_class, departure timestamps (including hidden departures), airline, stops, stop_notes, duration_hours, and variant flags.
+- Per-leg fields cover origin_code, destination_code, price, currency, seat_class, departure timestamps (including hidden departures), airline, stops, stop_notes, duration_hours, and variant flags.
 - Totals include `total_price`, `total_currency`, and aggregated `total_duration_hours` when data is complete.
 - Tune `leg_limit` (flights per leg, 0 = unlimited, 10 recommended) and `max_combinations` (0 = unlimited) to balance coverage versus file size.
 
@@ -178,4 +178,4 @@ Each plan expands airport combinations and departure calendars automatically.
 - Provide a PYPI_TOKEN secret with publish permissions.
 - Select current to reuse the existing version during manual runs.
 
-Last commit id: a77b356d42a3438e8bb93f3d20d65ae482ea0832
+Last commit id: ee53d5f393f63bca27a81f4b9cfd4ddbad7a183d

--- a/awesome_cheap_flights/cli.py
+++ b/awesome_cheap_flights/cli.py
@@ -15,6 +15,7 @@ from .pipeline import (
     ItinerarySettings,
     LegDeparture,
     LegFilter,
+    PlanLeg,
     PlanConfig,
     PlanOptions,
     PlanOutput,
@@ -166,24 +167,10 @@ def parse_places(raw: Any) -> Dict[str, List[str]]:
     return places
 
 
-def parse_path(raw: Any) -> List[str]:
-    if not isinstance(raw, (list, tuple)):
-        raise ValueError("Plan requires 'path' list")
-    path: List[str] = []
-    for entry in raw:
-        token = strip_comment(entry)
-        if not token:
-            raise ValueError("Path entries must be non-empty strings")
-        path.append(token)
-    if len(path) < 2:
-        raise ValueError("Path must contain at least two points")
-    return path
-
-
-def parse_departures(raw: Any) -> Dict[tuple[str, str], LegDeparture]:
+def parse_departures(raw: Any) -> List[PlanLeg]:
     if not isinstance(raw, dict):
         raise ValueError("Plan requires 'departures' mapping")
-    departures: Dict[tuple[str, str], LegDeparture] = {}
+    departures: List[PlanLeg] = []
     for key, value in raw.items():
         origin, destination = _parse_leg_key(key)
         selector = value
@@ -198,7 +185,15 @@ def parse_departures(raw: Any) -> Dict[tuple[str, str], LegDeparture]:
         dates = _expand_date_selector(selector)
         if not dates:
             raise ValueError(f"Leg {origin}->{destination} produced no dates")
-        departures[(origin, destination)] = LegDeparture(dates=dates, max_stops=max_stops)
+        departures.append(
+            PlanLeg(
+                origin_place=origin,
+                destination_place=destination,
+                departure=LegDeparture(dates=dates, max_stops=max_stops),
+            )
+        )
+    if not departures:
+        raise ValueError("Plan requires at least one departures entry")
     return departures
 
 
@@ -256,19 +251,22 @@ def parse_plan(raw: Any, defaults: FilterSettings) -> PlanConfig:
     if not name:
         raise ValueError("Plan missing 'name'")
     places = parse_places(raw.get("places"))
-    path = parse_path(raw.get("path"))
-    departures = parse_departures(raw.get("departures"))
+    if "path" in raw:
+        raise ValueError(
+            f"Plan '{name}' uses deprecated 'path'. Remove it and order legs via 'departures'."
+        )
+    legs = parse_departures(raw.get("departures"))
     options = parse_plan_options(raw.get("options"), defaults)
     filters = parse_plan_filters(raw.get("filters"))
     output = parse_plan_output(raw.get("output")) if raw.get("output") is not None else None
-    for place in path:
-        if place not in places:
-            raise ValueError(f"Plan '{name}' path references undefined place '{place}'")
+    for leg in legs:
+        for place in (leg.origin_place, leg.destination_place):
+            if place not in places:
+                raise ValueError(f"Plan '{name}' departures references undefined place '{place}'")
     return PlanConfig(
         name=name,
         places=places,
-        path=path,
-        departures=departures,
+        legs=legs,
         options=options,
         filters=filters,
         output=output,

--- a/awesome_cheap_flights/pipeline.py
+++ b/awesome_cheap_flights/pipeline.py
@@ -43,6 +43,11 @@ TIME_PATTERN = re.compile(
 
 DURATION_PATTERN = re.compile(r'(?:(?P<hours>\d+)\s*h(?:ours?)?)?(?:\s*(?P<minutes>\d+)\s*m(?:in)?)?', re.IGNORECASE)
 TIME_LABEL_PATTERN = re.compile(r"(\d{1,2}:\d{2})\s*(AM|PM)?", re.IGNORECASE)
+LAYOVER_ARIA_PATTERN = re.compile(
+    r"Layover(?: \(\d+ of \d+\))? is a (?P<duration>.+?) layover at "
+    r"(?P<airport>.+?)(?: in (?P<city>[^.]+))?\.",
+    re.IGNORECASE,
+)
 
 DEFAULT_ITINERARY_LEG_LIMIT = 0
 DEFAULT_ITINERARY_MAX_COMBINATIONS = 0
@@ -563,6 +568,7 @@ class LegFlight:
 class LayoverDetails:
     stop_text: str
     layover_codes: str
+    layover_notes: str
     hidden_departure_at: str
 
 
@@ -669,6 +675,53 @@ def _build_hidden_departure_labels(values: Sequence[str]) -> str:
     return " · ".join(labels)
 
 
+def _extract_layover_notes(item, layover_codes: str) -> str:
+    aria_labels: List[str] = []
+    for node in item.css(".sSHqwe.tPgKwe.ogfYpf"):
+        aria_value = " ".join(node.attributes.get("aria-label", "").split())
+        if not aria_value or "layover" not in aria_value.lower():
+            continue
+        if aria_value not in aria_labels:
+            aria_labels.append(aria_value)
+    if not aria_labels:
+        return ""
+
+    code_tokens = [token for token in layover_codes.split() if token]
+    notes: List[str] = []
+    for label in aria_labels:
+        for idx, match in enumerate(LAYOVER_ARIA_PATTERN.finditer(label)):
+            duration = " ".join(match.group("duration").split())
+            city = " ".join((match.group("city") or "").split())
+            if not duration:
+                continue
+            prefix = code_tokens[idx] if idx < len(code_tokens) else ""
+            if prefix and city:
+                notes.append(f"{prefix} {city} ({duration})")
+            elif prefix:
+                notes.append(f"{prefix} ({duration})")
+            elif city:
+                notes.append(f"{city} ({duration})")
+            else:
+                airport = " ".join((match.group("airport") or "").split())
+                if airport:
+                    notes.append(f"{airport} ({duration})")
+    return "; ".join(notes)
+
+
+def _compose_stop_notes(
+    *,
+    destination_code: str,
+    layover_codes: str,
+    layover_notes: str,
+    stop_text: str,
+) -> str:
+    destination_note = f"ARR {destination_code}" if destination_code else ""
+    layover_note = layover_notes or layover_codes or extract_stop_codes(stop_text)
+    if destination_note and layover_note:
+        return f"{destination_note} | STOPOVER {layover_note}"
+    return destination_note or layover_note
+
+
 def split_datetime_components(timestamp: str) -> Tuple[str, str]:
     if not timestamp:
         return "", ""
@@ -741,6 +794,7 @@ def parse_layover_details(html: str) -> Dict[Tuple[str, str, str], LayoverDetail
                 if val and val not in layover_values:
                     layover_values.append(val)
             layover_codes = extract_stop_codes(" ".join(layover_values))
+            layover_notes = _extract_layover_notes(item, layover_codes)
             hidden_departure_at = _build_hidden_departure_labels(layover_values)
             key = (name, " ".join(departure_time.split()), price_clean)
             details.setdefault(
@@ -748,6 +802,7 @@ def parse_layover_details(html: str) -> Dict[Tuple[str, str, str], LayoverDetail
                 LayoverDetails(
                     stop_text=stop_text,
                     layover_codes=layover_codes,
+                    layover_notes=layover_notes,
                     hidden_departure_at=hidden_departure_at,
                 ),
             )
@@ -879,8 +934,14 @@ def fetch_leg_flights(
         layover = layover_lookup.get(key)
         stop_text = layover.stop_text if layover else ""
         layover_codes = layover.layover_codes if layover else ""
+        layover_notes = layover.layover_notes if layover else ""
         hidden_departure = layover.hidden_departure_at if layover else ""
-        notes = layover_codes or extract_stop_codes(stop_text)
+        notes = _compose_stop_notes(
+            destination_code=destination_code,
+            layover_codes=layover_codes,
+            layover_notes=layover_notes,
+            stop_text=stop_text,
+        )
         flights.append(
             LegFlight(
                 airline_name=flight.name,
@@ -1070,6 +1131,8 @@ def _build_leg_key(row: SegmentRow) -> str:
 
 
 LEG_EXPORT_FIELDS = (
+    "origin_code",
+    "destination_code",
     "price",
     "currency",
     "seat_class",
@@ -1532,7 +1595,10 @@ def _resolve_leg_max_stops(
 def _flight_contains_codes(flight: LegFlight, codes: Sequence[str]) -> bool:
     if not codes:
         return True
-    haystack = f"{flight.stop_notes} {flight.stops}"
+    note = flight.stop_notes or ""
+    if "STOPOVER" in note:
+        _, _, note = note.partition("STOPOVER")
+    haystack = f"{note} {flight.stops}"
     found = {token.upper() for token in extract_stop_codes(haystack).split() if token}
     return all(code.upper() in found for code in codes)
 

--- a/awesome_cheap_flights/pipeline.py
+++ b/awesome_cheap_flights/pipeline.py
@@ -650,6 +650,12 @@ def parse_price_to_int(price: str) -> Optional[int]:
     return int(digits) if digits else None
 
 
+def _format_price(value: Optional[int]) -> object:
+    if value is None:
+        return "N/A"
+    return value
+
+
 def parse_duration_to_hours(raw: str) -> Optional[float]:
     if not raw:
         return None
@@ -1220,7 +1226,10 @@ def _build_plan_itinerary_combinations(
             for row in combo:
                 leg_key = _build_leg_key(row)
                 for field in LEG_EXPORT_FIELDS:
-                    record[f"{leg_key}_{field}"] = getattr(row, field)
+                    value = getattr(row, field)
+                    if field == "price":
+                        value = _format_price(value)
+                    record[f"{leg_key}_{field}"] = value
                 if row.price is not None:
                     total_price += row.price
                 else:
@@ -1229,7 +1238,7 @@ def _build_plan_itinerary_combinations(
                     total_duration += row.duration_hours
                 if row.currency:
                     currency = row.currency
-            record["total_price"] = total_price if price_complete else None
+            record["total_price"] = total_price if price_complete else "N/A"
             record["total_currency"] = currency
             record["total_duration_hours"] = round(total_duration, 2) if total_duration else None
             combinations.append(record)
@@ -1241,8 +1250,10 @@ def _build_plan_itinerary_combinations(
 
     combinations.sort(
         key=lambda entry: (
-            entry.get("total_price") is None,
-            entry.get("total_price") if entry.get("total_price") is not None else float("inf"),
+            not isinstance(entry.get("total_price"), (int, float)),
+            entry.get("total_price")
+            if isinstance(entry.get("total_price"), (int, float))
+            else float("inf"),
             entry.get("journey_id"),
         )
     )
@@ -1317,6 +1328,8 @@ def _segment_row_from_mapping(row: Dict[str, str]) -> SegmentRow:
 
     def parse_int(value: str) -> Optional[int]:
         value = value.strip()
+        if value.upper() == "N/A":
+            return None
         if not value:
             return None
         try:
@@ -2016,7 +2029,10 @@ def write_csv(
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
             writer.writeheader()
             for row in rows:
-                writer.writerow(asdict(row))
+                row_data = asdict(row)
+                if row_data.get("price") is None:
+                    row_data["price"] = "N/A"
+                writer.writerow(row_data)
         return
     header_fields = [field.name for field in fields(SegmentRow)]
     if not include_header_only:

--- a/awesome_cheap_flights/pipeline.py
+++ b/awesome_cheap_flights/pipeline.py
@@ -168,7 +168,10 @@ class ProgressReporter:
         table.add_column("Field", justify="left")
         table.add_column("Value", justify="right")
         table.add_row("Plan", self._plan.name)
-        table.add_row("Path", " → ".join(self._plan.path))
+        leg_label = " | ".join(
+            f"{leg.origin_place}->{leg.destination_place}" for leg in self._plan.legs
+        )
+        table.add_row("Legs", leg_label or "-")
         table.add_row("Journeys", str(self.total_steps))
         table.add_row("Passengers", str(self._config.passenger_count))
         table.add_row("Currency", self._config.currency_code)
@@ -502,11 +505,25 @@ class LegDeparture:
 
 
 @dataclass
+class PlanLeg:
+    origin_place: str
+    destination_place: str
+    departure: LegDeparture
+
+    def __post_init__(self) -> None:
+        self.origin_place = str(self.origin_place or "").strip()
+        self.destination_place = str(self.destination_place or "").strip()
+        if not self.origin_place or not self.destination_place:
+            raise ValueError("Plan leg requires non-empty origin_place and destination_place")
+        if not isinstance(self.departure, LegDeparture):
+            raise ValueError("Plan leg requires a LegDeparture value")
+
+
+@dataclass
 class PlanConfig:
     name: str
     places: Dict[str, List[str]]
-    path: List[str]
-    departures: Dict[Tuple[str, str], LegDeparture]
+    legs: List[PlanLeg]
     options: PlanOptions
     filters: Dict[Tuple[str, str], LegFilter]
     output: Optional[PlanOutput] = None
@@ -515,7 +532,7 @@ class PlanConfig:
 @dataclass
 class PlanExecution:
     assignment: Dict[str, str]
-    departures: Dict[Tuple[str, str], str]
+    departure_dates: List[str]
 
 
 @dataclass
@@ -959,14 +976,26 @@ def fetch_leg_flights(
     return flights
 
 
-def _iter_edges(path: Sequence[str]) -> List[Tuple[str, str]]:
-    return [(path[idx], path[idx + 1]) for idx in range(len(path) - 1)]
+def _plan_place_keys(plan: PlanConfig) -> List[str]:
+    ordered: List[str] = []
+    seen: set[str] = set()
+    for leg in plan.legs:
+        for place in (leg.origin_place, leg.destination_place):
+            if place in seen:
+                continue
+            seen.add(place)
+            ordered.append(place)
+    return ordered
 
 
-def _iter_hidden_pairs(path: Sequence[str]) -> Iterable[Tuple[int, int]]:
-    for start in range(len(path) - 2):
-        end = start + 2
-        if path[start] == path[end]:
+def _iter_hidden_pairs(legs: Sequence[PlanLeg]) -> Iterable[Tuple[int, int]]:
+    for start in range(len(legs) - 1):
+        end = start + 1
+        first_leg = legs[start]
+        second_leg = legs[end]
+        if first_leg.destination_place != second_leg.origin_place:
+            continue
+        if first_leg.origin_place == second_leg.destination_place:
             continue
         yield start, end
 
@@ -1004,11 +1033,9 @@ def _build_journey_label(
     *,
     journey_index: int,
 ) -> str:
-    edges = _iter_edges(plan.path)
-    first_edge = edges[0] if edges else None
-    first_date = execution.departures.get(first_edge, "?") if first_edge else "?"
-    origin_place = plan.path[0] if plan.path else "?"
-    destination_place = plan.path[-1] if plan.path else "?"
+    first_date = execution.departure_dates[0] if execution.departure_dates else "?"
+    origin_place = plan.legs[0].origin_place if plan.legs else "?"
+    destination_place = plan.legs[-1].destination_place if plan.legs else "?"
     origin_code = execution.assignment.get(origin_place, "?")
     destination_code = execution.assignment.get(destination_place, "?")
     return (
@@ -1159,7 +1186,7 @@ def _build_plan_itinerary_combinations(
         journeys[row.journey_id].append(row)
 
     combinations: List[Dict[str, object]] = []
-    expected_leg_count = max(len(plan.path) - 1, 0)
+    expected_leg_count = len(plan.legs)
     truncated = False
     clamped = False
 
@@ -1228,7 +1255,7 @@ def _build_summary_headers(
 ) -> List[str]:
     base_headers = ["plan_name", "journey_id", "journey_label"]
     leg_headers: List[str] = []
-    leg_keys = [f"{plan.path[idx]}->{plan.path[idx + 1]}" for idx in range(max(len(plan.path) - 1, 0))]
+    leg_keys = [f"{leg.origin_place}->{leg.destination_place}" for leg in plan.legs]
     for leg_key in leg_keys:
         for field in LEG_EXPORT_FIELDS:
             leg_headers.append(f"{leg_key}_{field}")
@@ -1401,21 +1428,6 @@ def _infer_plan_config_from_segments(plan_name: str, rows: Sequence[SegmentRow])
     if not ordered_sequences:
         raise ValueError("Unable to infer leg order from CSV")
 
-    raw_path: List[str] = []
-    for seq in ordered_sequences:
-        sample = scheduled_map[seq][0]
-        if not raw_path:
-            raw_path.append(sample.origin_place)
-        if raw_path[-1] != sample.origin_place:
-            raw_path.append(sample.origin_place)
-        raw_path.append(sample.destination_place)
-    dedup_path: List[str] = []
-    for place in raw_path:
-        if not dedup_path or dedup_path[-1] != place:
-            dedup_path.append(place)
-    if len(dedup_path) < 2:
-        raise ValueError("Inferred path must contain at least two points")
-
     place_codes: Dict[str, List[str]] = {}
     codes_map: Dict[str, set[str]] = defaultdict(set)
     for row in rows:
@@ -1426,23 +1438,29 @@ def _infer_plan_config_from_segments(plan_name: str, rows: Sequence[SegmentRow])
         if not place_codes[place]:
             place_codes[place] = [""]
 
-    departures: Dict[Tuple[str, str], LegDeparture] = {}
+    legs: List[PlanLeg] = []
     for seq in ordered_sequences:
         samples = scheduled_map[seq]
         sample = samples[0]
-        key = (sample.origin_place, sample.destination_place)
         dates = sorted({row.departure_date for row in samples if row.departure_date})
         if not dates:
             dates = ["1970-01-01"]
-        departures[key] = LegDeparture(dates=dates)
+        legs.append(
+            PlanLeg(
+                origin_place=sample.origin_place,
+                destination_place=sample.destination_place,
+                departure=LegDeparture(dates=dates),
+            )
+        )
+    if not legs:
+        raise ValueError("Unable to infer departures from CSV")
 
     options = PlanOptions(include_hidden=any(row.variant == "hidden" for row in rows), max_hidden_hops=1)
     plan_filters: Dict[Tuple[str, str], LegFilter] = {}
     return PlanConfig(
         name=plan_name,
         places=place_codes,
-        path=dedup_path,
-        departures=departures,
+        legs=legs,
         options=options,
         filters=plan_filters,
         output=None,
@@ -1557,11 +1575,11 @@ def _build_progress_label(
     total: int,
     config: SearchConfig,
 ) -> str:
-    origin_code = execution.assignment.get(plan.path[0], "?") if plan.path else "?"
-    destination_code = execution.assignment.get(plan.path[-1], "?") if plan.path else "?"
-    edges = _iter_edges(plan.path)
-    first_edge = edges[0] if edges else None
-    first_date = execution.departures.get(first_edge, "?") if first_edge else "?"
+    origin_place = plan.legs[0].origin_place if plan.legs else "?"
+    destination_place = plan.legs[-1].destination_place if plan.legs else "?"
+    origin_code = execution.assignment.get(origin_place, "?")
+    destination_code = execution.assignment.get(destination_place, "?")
+    first_date = execution.departure_dates[0] if execution.departure_dates else "?"
     return (
         f"{plan.name} #{journey_index}/{total} "
         f"{origin_code}->{destination_code} {first_date} · "
@@ -1572,8 +1590,7 @@ def _build_progress_label(
 def _resolve_leg_max_stops(
     config: SearchConfig,
     plan: PlanConfig,
-    origin_place: str,
-    destination_place: str,
+    leg: PlanLeg,
     *,
     hidden: bool,
 ) -> Optional[int]:
@@ -1583,10 +1600,9 @@ def _resolve_leg_max_stops(
         if global_limit is not None:
             limit = min(limit, global_limit)
         return limit
-    leg_departure = plan.departures.get((origin_place, destination_place))
-    if leg_departure and leg_departure.max_stops is not None:
-        return leg_departure.max_stops
-    override = plan.filters.get((origin_place, destination_place))
+    if leg.departure.max_stops is not None:
+        return leg.departure.max_stops
+    override = plan.filters.get((leg.origin_place, leg.destination_place))
     if override and override.max_stops is not None:
         return override.max_stops
     return config.filters.max_stops
@@ -1665,16 +1681,21 @@ def collect_segments_for_execution(
     reporter: Optional[ProgressReporter],
 ) -> List[SegmentRow]:
     rows: List[SegmentRow] = []
-    edges = _iter_edges(plan.path)
     journey_id = f"{_slugify_plan_name(plan.name)}-{journey_index:04d}"
 
-    for seq_index, (origin_place, destination_place) in enumerate(edges):
+    for seq_index, leg in enumerate(plan.legs):
+        origin_place = leg.origin_place
+        destination_place = leg.destination_place
         origin_code = execution.assignment.get(origin_place)
         destination_code = execution.assignment.get(destination_place)
         if not origin_code or not destination_code:
             _warn(f"Missing airport code for {origin_place}->{destination_place}", reporter)
             continue
-        departure_date = execution.departures.get((origin_place, destination_place))
+        departure_date = (
+            execution.departure_dates[seq_index]
+            if seq_index < len(execution.departure_dates)
+            else ""
+        )
         if not departure_date:
             _warn(
                 f"Missing departure date for {origin_place}->{destination_place}",
@@ -1684,8 +1705,7 @@ def collect_segments_for_execution(
         max_stops = _resolve_leg_max_stops(
             config,
             plan,
-            origin_place,
-            destination_place,
+            leg,
             hidden=False,
         )
         flights = fetch_leg_flights(
@@ -1718,13 +1738,13 @@ def collect_segments_for_execution(
             time.sleep(config.request.delay)
 
     if plan.options.include_hidden:
-        hidden_offset = len(edges)
-        for hidden_index, (start_idx, end_idx) in enumerate(_iter_hidden_pairs(plan.path)):
-            origin_place = plan.path[start_idx]
-            destination_place = plan.path[end_idx]
-            via_places = plan.path[start_idx + 1 : end_idx]
-            if not via_places:
-                continue
+        hidden_offset = len(plan.legs)
+        for hidden_index, (start_idx, end_idx) in enumerate(_iter_hidden_pairs(plan.legs)):
+            first_leg = plan.legs[start_idx]
+            second_leg = plan.legs[end_idx]
+            origin_place = first_leg.origin_place
+            destination_place = second_leg.destination_place
+            via_places = [first_leg.destination_place]
             origin_code = execution.assignment.get(origin_place)
             destination_code = execution.assignment.get(destination_place)
             via_codes = [execution.assignment.get(place, "") for place in via_places]
@@ -1734,8 +1754,11 @@ def collect_segments_for_execution(
                     reporter,
                 )
                 continue
-            first_edge = (plan.path[start_idx], plan.path[start_idx + 1])
-            departure_date = execution.departures.get(first_edge)
+            departure_date = (
+                execution.departure_dates[start_idx]
+                if start_idx < len(execution.departure_dates)
+                else ""
+            )
             if not departure_date:
                 _warn(
                     f"Missing departure date for hidden path {origin_place}->{destination_place}",
@@ -1745,8 +1768,7 @@ def collect_segments_for_execution(
             hidden_limit = _resolve_leg_max_stops(
                 config,
                 plan,
-                origin_place,
-                destination_place,
+                first_leg,
                 hidden=True,
             )
             if hidden_limit <= 0:
@@ -1789,29 +1811,32 @@ def collect_segments_for_execution(
 
 
 def run_plan(config: SearchConfig, plan: PlanConfig) -> PlanRunResult:
-    if len(plan.path) < 2:
-        raise ValueError(f"Plan '{plan.name}' requires at least two path entries")
-    for place in plan.path:
-        if place not in plan.places:
-            raise ValueError(f"Plan '{plan.name}' is missing place '{place}' definition")
+    if not plan.legs:
+        raise ValueError(f"Plan '{plan.name}' requires at least one departure leg")
+    for leg in plan.legs:
+        if leg.origin_place not in plan.places:
+            raise ValueError(f"Plan '{plan.name}' is missing place '{leg.origin_place}' definition")
+        if leg.destination_place not in plan.places:
+            raise ValueError(f"Plan '{plan.name}' is missing place '{leg.destination_place}' definition")
     for key, codes in plan.places.items():
         if not codes:
             raise ValueError(f"Plan '{plan.name}' place '{key}' has no airport codes")
 
     output_path = _resolve_plan_output_path(config, plan)
-    edges = _iter_edges(plan.path)
-    departure_entries = [plan.departures.get(edge) for edge in edges]
-    for edge, entry in zip(edges, departure_entries):
-        if entry is None or not entry.dates:
+    departure_entries = [leg.departure for leg in plan.legs]
+    for leg, entry in zip(plan.legs, departure_entries):
+        if not entry.dates:
             raise ValueError(
-                f"Plan '{plan.name}' missing departure dates for {edge[0]}->{edge[1]}"
+                f"Plan '{plan.name}' missing departure dates for {leg.origin_place}->{leg.destination_place}"
             )
 
-    place_keys = list(plan.places.keys())
+    place_keys = _plan_place_keys(plan)
     code_options = [plan.places[key] for key in place_keys]
     long_span_alerts: List[str] = []
-    for origin, destination in edges:
-        entry = plan.departures[(origin, destination)]
+    for leg in plan.legs:
+        origin = leg.origin_place
+        destination = leg.destination_place
+        entry = leg.departure
         unique_dates = sorted({date_token for date_token in entry.dates})
         parsed_dates = [
             datetime.strptime(date_token, "%Y-%m-%d") for date_token in unique_dates
@@ -1837,8 +1862,12 @@ def run_plan(config: SearchConfig, plan: PlanConfig) -> PlanRunResult:
     for codes in product(*code_options):
         assignment = dict(zip(place_keys, codes))
         for date_combo in product(*(entry.dates for entry in departure_entries)):
-            departures = {edge: date for edge, date in zip(edges, date_combo)}
-            executions.append(PlanExecution(assignment=assignment, departures=departures))
+            executions.append(
+                PlanExecution(
+                    assignment=assignment,
+                    departure_dates=list(date_combo),
+                )
+            )
 
     total_steps = len(executions)
     rows: List[SegmentRow] = []

--- a/config-dg.yaml
+++ b/config-dg.yaml
@@ -23,26 +23,26 @@ plans:
   - name: lax-asia-pe-only
     places:
       icn:
-        - ICN
-      schina:
-        - HKG  # Hong Kong
-        - SZX  # Hong Kong
-        - CAN  # Hong Kong\
+        - ICN  # Seoul Incheon
+      hkgszx:
+        - HKG
+        - SZX
+      szx:
+        - SZX
       ckg:
         - CKG  # Chongqing
-      icn:
-        - ICN  # Seoul Incheon
-    path: [icn, schina, ckg, icn]
+    # Departure key order defines leg order.
+    # Missing links between keys are treated as surface transfer.
     departures:
-      "icn->schina":
+      "icn->hkgszx":
         window:
           start: "2026-02-24"
           end: "2026-02-25"
-      "schina->ckg":
-        dates: ["2026-03-07"]
+      "szx->ckg":
+        dates: ["2026-03-07","2026-03-08"]
       "ckg->icn":
         window:
-          start: "2026-03-12"
+          start: "2026-03-11"
           end: "2026-03-13"
     options:
       include_hidden: true

--- a/config-dg.yaml
+++ b/config-dg.yaml
@@ -1,0 +1,53 @@
+schema_version: v2
+
+defaults:
+  currency: USD
+  passengers: 1
+  request:
+    delay: 0.5
+    retries: 2
+    max_leg_results: 10
+    seat: economy  # Premium Economy ONLY
+  filters:
+    max_stops: 2
+    include_hidden: true
+    max_hidden_hops: 1
+  output:
+    directory: output
+    filename_pattern: "{plan}_{timestamp}.csv"
+  itinerary:
+    leg_limit: 0
+    max_combinations: 0
+
+plans:
+  - name: lax-asia-pe-only
+    places:
+      icn:
+        - ICN
+      schina:
+        - HKG  # Hong Kong
+        - SZX  # Hong Kong
+        - CAN  # Hong Kong\
+      ckg:
+        - CKG  # Chongqing
+      icn:
+        - ICN  # Seoul Incheon
+    path: [icn, schina, ckg, icn]
+    departures:
+      "icn->schina":
+        window:
+          start: "2026-02-24"
+          end: "2026-02-25"
+      "schina->ckg":
+        dates: ["2026-03-07"]
+      "ckg->icn":
+        window:
+          start: "2026-03-12"
+          end: "2026-03-13"
+    options:
+      include_hidden: true
+      max_hidden_hops: 1
+
+google_cookie_file: null
+http_proxy: null
+concurrency: 5

--- a/config-dg.yaml
+++ b/config-dg.yaml
@@ -7,7 +7,7 @@ defaults:
     delay: 0.5
     retries: 2
     max_leg_results: 10
-    seat: economy  # Premium Economy ONLY
+    seat: premium-economy
   filters:
     max_stops: 2
     include_hidden: true

--- a/my_trip.yaml
+++ b/my_trip.yaml
@@ -1,0 +1,32 @@
+schema_version: v2
+defaults:
+  currency: USD
+plans:
+  - name: lax-asia-icn-biz
+    places:
+      home: [LAX]
+      stop: [PEK, PVG, HKG, HND, NRT]
+dest: [ICN]
+    path: [home, stop, dest]
+    defaults:
+      request:
+        seat: business
+    departures:
+      "home->stop":
+        dates: ["2026-01-18"]
+      "stop->dest":
+        window: { start: "2026-01-21", end: "2026-01-25" }
+  - name: lax-asia-icn-pre
+    places:
+      home: [LAX]
+      stop: [PEK, PVG, HKG, HND, NRT]
+dest: [ICN]
+    path: [home, stop, dest]
+    defaults:
+      request:
+        seat: premium-economy
+    departures:
+      "home->stop":
+        dates: ["2026-01-18"]
+      "stop->dest":
+        window: { start: "2026-01-21", end: "2026-01-25" }

--- a/my_trip.yaml
+++ b/my_trip.yaml
@@ -1,32 +1,31 @@
 schema_version: v2
+
 defaults:
   currency: USD
+
 plans:
   - name: lax-asia-icn-biz
     places:
       home: [LAX]
       stop: [PEK, PVG, HKG, HND, NRT]
-dest: [ICN]
-    path: [home, stop, dest]
-    defaults:
-      request:
-        seat: business
+      dest: [ICN]
     departures:
       "home->stop":
         dates: ["2026-01-18"]
       "stop->dest":
         window: { start: "2026-01-21", end: "2026-01-25" }
+    request:
+      seat: business
+
   - name: lax-asia-icn-pre
     places:
       home: [LAX]
       stop: [PEK, PVG, HKG, HND, NRT]
-dest: [ICN]
-    path: [home, stop, dest]
-    defaults:
-      request:
-        seat: premium-economy
+      dest: [ICN]
     departures:
       "home->stop":
         dates: ["2026-01-18"]
       "stop->dest":
         window: { start: "2026-01-21", end: "2026-01-25" }
+    request:
+      seat: premium-economy

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -29,7 +29,7 @@ plans:
       city:
         - FUK # Fukuoka
         - HKG # Hong Kong
-    path: [home, city, home]
+    # Departure key order defines leg order.
     departures:
       "home->city":
         dates: ["2026-01-01", "2026-01-02"]   # Outbound departure choices.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,26 @@ from __future__ import annotations
 from argparse import Namespace
 from pathlib import Path
 
+import pytest
+
 from awesome_cheap_flights.cli import build_config
+
+
+def _build_args(config_path: Path) -> Namespace:
+    return Namespace(
+        config=str(config_path),
+        plan=None,
+        currency=None,
+        passengers=None,
+        http_proxy=None,
+        concurrency=None,
+        seat_class=None,
+        itinerary_leg_limit=None,
+        itinerary_max_combos=None,
+        csv_only=None,
+        output=None,
+        debug=False,
+    )
 
 
 def test_build_config_parses_v2_schema(tmp_path: Path) -> None:
@@ -37,7 +56,6 @@ def test_build_config_parses_v2_schema(tmp_path: Path) -> None:
                 "home": ["ICN"],
                 "beach": ["CEB"]
               },
-              "path": ["home", "beach"],
               "departures": {
                 "home->beach": {
                   "dates": ["2026-03-01", "2026-03-02"]
@@ -49,15 +67,7 @@ def test_build_config_parses_v2_schema(tmp_path: Path) -> None:
         """,
         encoding="utf-8",
     )
-    args = Namespace(
-        config=str(config_path),
-        plan=None,
-        currency=None,
-        passengers=None,
-        http_proxy=None,
-        concurrency=None,
-        debug=False,
-    )
+    args = _build_args(config_path)
 
     config = build_config(args)
 
@@ -74,6 +84,49 @@ def test_build_config_parses_v2_schema(tmp_path: Path) -> None:
     plan = config.plans[0]
     assert plan.name == "demo"
     assert plan.places["home"] == ["ICN"]
-    leg = plan.departures[("home", "beach")]
-    assert leg.dates == ["2026-03-01", "2026-03-02"]
-    assert leg.max_stops is None
+    assert len(plan.legs) == 1
+    leg = plan.legs[0]
+    assert leg.origin_place == "home"
+    assert leg.destination_place == "beach"
+    assert leg.departure.dates == ["2026-03-01", "2026-03-02"]
+    assert leg.departure.max_stops is None
+
+
+def test_build_config_rejects_legacy_path(tmp_path: Path) -> None:
+    config_path = tmp_path / "legacy-path.yaml"
+    config_path.write_text(
+        """
+schema_version: v2
+plans:
+  - name: legacy
+    places:
+      a: [ICN]
+      b: [HKG]
+    path: [a, b]
+    departures:
+      "a->b":
+        dates: ["2026-03-01"]
+        """,
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="deprecated 'path'"):
+        build_config(_build_args(config_path))
+
+
+def test_build_config_rejects_unknown_departure_place(tmp_path: Path) -> None:
+    config_path = tmp_path / "unknown-place.yaml"
+    config_path.write_text(
+        """
+schema_version: v2
+plans:
+  - name: bad
+    places:
+      home: [ICN]
+    departures:
+      "home->missing":
+        dates: ["2026-03-01"]
+        """,
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="undefined place 'missing'"):
+        build_config(_build_args(config_path))

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -18,11 +18,15 @@ from awesome_cheap_flights.pipeline import (
     PlanOutput,
     RequestSettings,
     SearchConfig,
+    SegmentRow,
+    _build_plan_itinerary_combinations,
     _build_summary_headers,
     _compose_stop_notes,
     _extract_layover_notes,
     _flight_contains_codes,
+    _segment_row_from_mapping,
     run_plan,
+    write_csv,
 )
 from selectolax.lexbor import LexborHTMLParser
 
@@ -280,3 +284,133 @@ def test_hidden_filter_ignores_arrival_code_in_stop_notes() -> None:
     )
     assert _flight_contains_codes(flight, ["HKG"])
     assert not _flight_contains_codes(flight, ["SZX"])
+
+
+def test_write_csv_outputs_na_for_missing_price(tmp_path: Path) -> None:
+    row = SegmentRow(
+        plan_name="demo",
+        journey_id="demo-0001",
+        journey_label="demo-0001 ICN->SIN 2026-03-01",
+        variant="scheduled",
+        leg_sequence=0,
+        origin_place="home",
+        origin_code="ICN",
+        destination_place="dest",
+        destination_code="SIN",
+        hidden_via_places="",
+        hidden_via_codes="",
+        departure_date="2026-03-01",
+        departure_at="2026-03-01 09:00:00",
+        departure_time="09:00",
+        duration_hours=6.5,
+        airline="DemoAir",
+        stops="Nonstop",
+        stop_notes="ARR SIN",
+        price=None,
+        is_best=True,
+        currency="USD",
+        seat_class="economy",
+        hidden_departure_at="",
+    )
+    csv_path = tmp_path / "rows.csv"
+    write_csv([row], csv_path)
+
+    text = csv_path.read_text(encoding="utf-8")
+    assert "N/A" in text
+
+
+def test_itinerary_combinations_show_na_for_missing_leg_price() -> None:
+    plan = _make_plan()
+    scheduled_rows = [
+        SegmentRow(
+            plan_name=plan.name,
+            journey_id="demo-0001",
+            journey_label="demo-0001 ICN->SIN 2026-03-01",
+            variant="scheduled",
+            leg_sequence=0,
+            origin_place="home",
+            origin_code="ICN",
+            destination_place="via",
+            destination_code="HKG",
+            hidden_via_places="",
+            hidden_via_codes="",
+            departure_date="2026-03-01",
+            departure_at="2026-03-01 09:00:00",
+            departure_time="09:00",
+            duration_hours=3.5,
+            airline="DemoAir",
+            stops="Nonstop",
+            stop_notes="ARR HKG",
+            price=150,
+            is_best=True,
+            currency="USD",
+            seat_class="economy",
+            hidden_departure_at="",
+        ),
+        SegmentRow(
+            plan_name=plan.name,
+            journey_id="demo-0001",
+            journey_label="demo-0001 ICN->SIN 2026-03-01",
+            variant="scheduled",
+            leg_sequence=1,
+            origin_place="via",
+            origin_code="HKG",
+            destination_place="dest",
+            destination_code="SIN",
+            hidden_via_places="",
+            hidden_via_codes="",
+            departure_date="2026-03-03",
+            departure_at="2026-03-03 08:00:00",
+            departure_time="08:00",
+            duration_hours=4.0,
+            airline="DemoAir",
+            stops="Nonstop",
+            stop_notes="ARR SIN",
+            price=None,
+            is_best=True,
+            currency="USD",
+            seat_class="economy",
+            hidden_departure_at="",
+        ),
+    ]
+
+    combos, _, _, _, _ = _build_plan_itinerary_combinations(
+        plan,
+        scheduled_rows,
+        ItinerarySettings(),
+    )
+    assert len(combos) == 1
+    record = combos[0]
+    assert record["via->dest_price"] == "N/A"
+    assert record["total_price"] == "N/A"
+
+
+def test_segment_row_parser_accepts_na_price() -> None:
+    parsed = _segment_row_from_mapping(
+        {
+            "plan_name": "demo",
+            "journey_id": "demo-0001",
+            "journey_label": "demo-0001 ICN->SIN 2026-03-01",
+            "variant": "scheduled",
+            "leg_sequence": "0",
+            "origin_place": "home",
+            "origin_code": "ICN",
+            "destination_place": "dest",
+            "destination_code": "SIN",
+            "hidden_via_places": "",
+            "hidden_via_codes": "",
+            "departure_date": "2026-03-01",
+            "departure_at": "2026-03-01 09:00:00",
+            "departure_time": "09:00",
+            "duration_hours": "6.5",
+            "airline": "DemoAir",
+            "stops": "Nonstop",
+            "stop_notes": "ARR SIN",
+            "price": "N/A",
+            "is_best": "true",
+            "currency": "USD",
+            "seat_class": "economy",
+            "hidden_departure_at": "",
+        }
+    )
+    assert parsed.price is None

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -17,8 +17,13 @@ from awesome_cheap_flights.pipeline import (
     PlanOutput,
     RequestSettings,
     SearchConfig,
+    _build_summary_headers,
+    _compose_stop_notes,
+    _extract_layover_notes,
+    _flight_contains_codes,
     run_plan,
 )
+from selectolax.lexbor import LexborHTMLParser
 
 
 def _make_plan() -> PlanConfig:
@@ -149,3 +154,54 @@ def test_departure_max_stops_override(monkeypatch: pytest.MonkeyPatch) -> None:
         if origin == "ICN" and destination == "HKG"
     )
     assert scheduled_call == 0
+
+
+def test_summary_headers_include_leg_destination_codes() -> None:
+    plan = _make_plan()
+    headers = _build_summary_headers(plan, [])
+    assert "home->via_destination_code" in headers
+    assert "via->dest_destination_code" in headers
+
+
+def test_layover_notes_prefer_code_and_city_with_duration() -> None:
+    html = """
+    <li>
+      <div class="sSHqwe tPgKwe ogfYpf"
+           aria-label="Layover (1 of 2) is a 7 hr 45 min overnight layover at Jinan Yaoqiang International Airport in Jinan. Layover (2 of 2) is a 45 min layover at Wuyishan Airport in Wuyishan."></div>
+    </li>
+    """
+    parser = LexborHTMLParser(html)
+    item = parser.css_first("li")
+    assert item is not None
+
+    layover_note = _extract_layover_notes(item, "TNA WUS")
+    assert layover_note == (
+        "TNA Jinan (7 hr 45 min overnight); "
+        "WUS Wuyishan (45 min)"
+    )
+
+    stop_notes = _compose_stop_notes(
+        destination_code="SZX",
+        layover_codes="TNA WUS",
+        layover_notes=layover_note,
+        stop_text="2 stops",
+    )
+    assert stop_notes.startswith("ARR SZX | STOPOVER ")
+    assert "TNA Jinan" in stop_notes
+    assert "7 hr 45 min overnight" in stop_notes
+
+
+def test_hidden_filter_ignores_arrival_code_in_stop_notes() -> None:
+    flight = LegFlight(
+        airline_name="HiddenJet",
+        departure_at="2026-03-01 07:30:00",
+        stops="1 stop",
+        stop_notes="ARR SZX | STOPOVER HKG Hong Kong (2 hr)",
+        duration_hours=6.5,
+        price=180,
+        is_best=False,
+        seat_class="economy",
+        hidden_departure_at="",
+    )
+    assert _flight_contains_codes(flight, ["HKG"])
+    assert not _flight_contains_codes(flight, ["SZX"])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -11,6 +11,7 @@ from awesome_cheap_flights.pipeline import (
     LegDeparture,
     LegFlight,
     OutputSettings,
+    PlanLeg,
     PlanConfig,
     PlanOptions,
     PlanRunResult,
@@ -30,11 +31,18 @@ def _make_plan() -> PlanConfig:
     return PlanConfig(
         name="demo",
         places={"home": ["ICN"], "via": ["HKG"], "dest": ["SIN"]},
-        path=["home", "via", "dest"],
-        departures={
-            ("home", "via"): LegDeparture(dates=["2026-03-01"]),
-            ("via", "dest"): LegDeparture(dates=["2026-03-03"]),
-        },
+        legs=[
+            PlanLeg(
+                origin_place="home",
+                destination_place="via",
+                departure=LegDeparture(dates=["2026-03-01"]),
+            ),
+            PlanLeg(
+                origin_place="via",
+                destination_place="dest",
+                departure=LegDeparture(dates=["2026-03-03"]),
+            ),
+        ],
         options=PlanOptions(include_hidden=True, max_hidden_hops=1),
         filters={},
         output=PlanOutput(filename="demo.csv"),
@@ -51,7 +59,6 @@ def _make_config(plan: PlanConfig) -> SearchConfig:
         output=OutputSettings(directory="output", filename_pattern="{plan}_{timestamp}.csv"),
         itinerary=ItinerarySettings(),
         http_proxy=None,
-        google_cookie=None,
         concurrency=1,
         debug=False,
         plans=[plan],
@@ -130,7 +137,7 @@ def test_run_plan_generates_hidden_rows(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
 def test_departure_max_stops_override(monkeypatch: pytest.MonkeyPatch) -> None:
     plan = _make_plan()
-    plan.departures[("home", "via")].max_stops = 0
+    plan.legs[0].departure.max_stops = 0
     config = _make_config(plan)
     captured: List[tuple[str, str, Optional[int]]] = []
 
@@ -161,6 +168,74 @@ def test_summary_headers_include_leg_destination_codes() -> None:
     headers = _build_summary_headers(plan, [])
     assert "home->via_destination_code" in headers
     assert "via->dest_destination_code" in headers
+
+
+def test_hidden_rows_skip_disconnected_surface_gap(monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = PlanConfig(
+        name="surface-gap",
+        places={"icn": ["ICN"], "hkg": ["HKG"], "szx": ["SZX"]},
+        legs=[
+            PlanLeg(
+                origin_place="icn",
+                destination_place="hkg",
+                departure=LegDeparture(dates=["2026-03-01"]),
+            ),
+            PlanLeg(
+                origin_place="szx",
+                destination_place="icn",
+                departure=LegDeparture(dates=["2026-03-07"]),
+            ),
+        ],
+        options=PlanOptions(include_hidden=True, max_hidden_hops=1),
+        filters={},
+        output=PlanOutput(filename="surface-gap.csv"),
+    )
+    config = _make_config(plan)
+    captured: List[tuple[str, str]] = []
+
+    def fake_fetch_leg_flights(**kwargs) -> List[LegFlight]:
+        captured.append((kwargs["origin_code"], kwargs["destination_code"]))
+        key = (kwargs["origin_code"], kwargs["destination_code"])
+        if key == ("ICN", "HKG"):
+            return [
+                LegFlight(
+                    airline_name="DemoAir",
+                    departure_at="2026-03-01 09:00:00",
+                    stops="Nonstop",
+                    stop_notes="",
+                    duration_hours=3.5,
+                    price=150,
+                    is_best=True,
+                    seat_class="economy",
+                    hidden_departure_at="",
+                )
+            ]
+        if key == ("SZX", "ICN"):
+            return [
+                LegFlight(
+                    airline_name="DemoAir",
+                    departure_at="2026-03-07 14:00:00",
+                    stops="Nonstop",
+                    stop_notes="",
+                    duration_hours=3.5,
+                    price=160,
+                    is_best=True,
+                    seat_class="economy",
+                    hidden_departure_at="",
+                )
+            ]
+        return []
+
+    monkeypatch.setattr("awesome_cheap_flights.pipeline.fetch_leg_flights", fake_fetch_leg_flights)
+
+    result = run_plan(config, plan)
+    scheduled = [row for row in result.rows if row.variant == "scheduled"]
+    hidden = [row for row in result.rows if row.variant == "hidden"]
+
+    assert len(scheduled) == 2
+    assert len(hidden) == 0
+    assert ("HKG", "SZX") not in captured
+    assert ("ICN", "ICN") not in captured
 
 
 def test_layover_notes_prefer_code_and_city_with_duration() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "awesome-cheap-flights"
-version = "1.0.0"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "fast-flights" },


### PR DESCRIPTION
## Summary
- refactor plan parsing to load ordered `departures` legs and drop the old `path` schema
- make pipeline execution, workbook headers, and CSV rebuild work from ordered scheduled legs while skipping implicit surface gaps
- refresh configs/docs, tests, and lockfile to align with the new plan model

## Testing
- Not run (not requested)